### PR TITLE
Always check for SOAP faults.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,11 @@
 Revision history for Business::Tax::VAT::Validation
 
+{NEXT}
+    - Check for SOAP faults, even if HTTP status is 200 (Issue #2) - sometimes
+      VIES will return a 200 OK status containing SOAP faults
+    - Change to return value for non-200 responses - now the error code is the
+      HTTP code, and the error message explains what we actually got
+
 1.12  20/03/2020
     - Use https:// base_url to avoid a redirect (fgehring)
 

--- a/lib/Business/Tax/VAT/Validation.pm
+++ b/lib/Business/Tax/VAT/Validation.pm
@@ -380,9 +380,9 @@ sub _is_res_ok {
         }
     }
 
-    # OK, no specific error given - more generally, check the HTTP status
+    # OK, no specific error given - more generally, check the HTTP status now
     if ($code != 200) {
-        return $self->_set_error( $code, $1.' '.$2 );
+        return $self->_set_error( $code, "Invalid response, HTTP $code, $res" );
     }
     if ($res=~m/^Can't connect to/) {
         # (Connection failure message returned by the VIES API, not we failed to

--- a/lib/Business/Tax/VAT/Validation.pm
+++ b/lib/Business/Tax/VAT/Validation.pm
@@ -380,7 +380,7 @@ sub _is_res_ok {
         }
     }
 
-    # OK, no specific error given - nor generally, check the HTTP status
+    # OK, no specific error given - more generally, check the HTTP status
     if ($code != 200) {
         return $self->_set_error( $code, $1.' '.$2 );
     }


### PR DESCRIPTION
As per Issue #2, sometimes we can get an error back from VIES with a faultcode
and faultstring but a 200 OK HTTP status, which is unhelpful.

So, refactor the checking around - first check for any reported SOAP faults,
then check the HTTP status is OK, and finally expect the response to be
successful and attempt to parse the expected validation results.

TODO: this wants some further refactoring and tidying.  In fact, I might just
start by running the whole file through perltidy :)