### PR TITLE
Update Base URL to HTTPS

### DIFF
--- a/lib/Business/Tax/VAT/Validation.pm
+++ b/lib/Business/Tax/VAT/Validation.pm
@@ -82,7 +82,7 @@ input that could never be valid.
 sub new {
     my ( $class, %arg ) = @_;
     my $self = {
-        baseurl      => $arg{baseurl} || 'http://ec.europa.eu/taxation_customs/vies/services/checkVatService',
+        baseurl      => $arg{baseurl} || 'https://ec.europa.eu/taxation_customs/vies/services/checkVatService',
         error        => '',
         error_code   => 0,
         response     => '',


### PR DESCRIPTION
Use HTTPS instead of HTTP for the base URL to avoid errors due to an attempted redirect