### PR TITLE
Remove SOAPAction header, EU service does not like it anymore. Fixes #12

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Business::Tax::VAT::Validation
 
+Upcoming changes:
+    - remove `soapaction` header, EU soap endpoint does not like it anymore, see #12
+
 1.20  01/04/2021 (Promoting 1.13 trial release to stable)
     - Changes as per 1.13 below - supporting UK/XI numbers via HMRC API
       courtesy of Dave Lambley (davel), GoDaddy
@@ -38,11 +41,11 @@ a full release as 1.20 soon.
 
 0.24  06/03/2012
     - Fix traderName field required for EL and ES MS
-                     Update POST request fields 
+                     Update POST request fields
 
 0.23  29/02/2012
     - Fix regexp in _is_res_ok with multiline regexp (Bart Heupers)
-	
+
 0.22  04/10/2011
     - Typo fix in POD error message #2 (Thanks to Martin H. Sluka)
     - Minor POD fixes (BPGN)
@@ -53,12 +56,12 @@ a full release as 1.20 soon.
 
 0.20  Mon Aug 18 2008
     - VIES HTML changes: now allowing multiples spaces (Thanks to Simon Williams, Benoît Galy & Raluca Boboia)
-    
+
 0.19  Tue, Apr 29 2008
     - HU regexp: missing digit "9" added (Thanks to Simon Williams)
-    
+
 0.18  Thu Jan 03 2008
-    - BE regexp: from transitional 9-digit & 10-digit format to 10-digit new format 
+    - BE regexp: from transitional 9-digit & 10-digit format to 10-digit new format
 
 0.17  Thu Jan 04 14:09:27 2008
     - BE regexp updated to new 10-digit format
@@ -66,7 +69,7 @@ a full release as 1.20 soon.
 0.16  Fri Jul 13 23:13:00 2007
     - Allowing spaces in regexps
     - t/03_distant_check moved to distant_checks/. If you really need to perform all tests against the VIES DB, simply copy the test files into "t/" directory before running "make test".
-    
+
 0.15  Fri Jul 06 18:26:12 2007
     - Added missing "keys" during $self->{members} constuction (Thanks to Dave O.)
     - Corrected returned 0-1 error codes inversion
@@ -84,12 +87,12 @@ a full release as 1.20 soon.
 0.13  Tue Jan 16 00:00:00 2007
     - VIES interface changed "not found" layout
     - (Thanks to Tom Kirkpatrick for this update)
-    
+
 0.12  Fri Nov 10 18:41:52 2006
        - Makefile.PL: current YAML compliance (licence & version fields)
 
 0.11  Fri Nov 10 12:41:48 2006
-       - Minor bug allowing one forbidden character corrected in Belgian regexp.                                      # 
+       - Minor bug allowing one forbidden character corrected in Belgian regexp.                                      #
          (Thanks to Andy Wardley for this report)
        - added regexps property for external testing purposes
        - POD CONSTRUCTOR. Some subs moved inside module.
@@ -103,10 +106,10 @@ a full release as 1.20 soon.
 0.08  Thu Jun 20 09:05:10 2006
     - 9 and 2 digits transitional format for Belgium
 	- Added member_states property allowing you to retreive valid MS values
-	
+
 0.07  Thu May 25 14:55:19 2006
         - Now we use "request" method not "simple request" in order to follow potential redirects
-          
+
 0.06  Thu May 25 14:44:14 2006
         - Updating VIES base URL
           (Thanks to Torsten Muller)
@@ -119,13 +122,13 @@ a full release as 1.20 soon.
         - Adding support for the "Member service unavailable" VIES's error.
 
 0.03  Mon Nov 01 15:23:16 2004
-        - Adding support for the 10 new EU countries. This update also includes an extra error code if the server returned a time out error. 
+        - Adding support for the 10 new EU countries. This update also includes an extra error code if the server returned a time out error.
           (Thanx to Robert Alloway, www.servicecentre.co.uk)
 
 0.02  Mon Sep 29 23:49:00 2003
         - Fix internal VAT checks: VAT numbers will be rejected if they contains non-numeric characters.
           Now, internal checks are performed by country dependent regeps (thanx to Robert Alloway)
-        
+
 0.01  Wed Aug 06 17:40:40 2003
 	- original version; created by h2xs 1.22 with options -XA -n Business::Tax::VAT::Validation
 

--- a/lib/Business/Tax/VAT/Validation.pm
+++ b/lib/Business/Tax/VAT/Validation.pm
@@ -42,16 +42,16 @@ Business::Tax::VAT::Validation - Validate EU VAT numbers against VIES/HMRC
 =head1 SYNOPSIS
 
   use Business::Tax::VAT::Validation;
-  
+
   my $hvatn=Business::Tax::VAT::Validation->new();
-  
+
   # Check number
   if ($hvatn->check($VAT, [$member_state])){
         print "OK\n";
   } else {
         print $hvatn->get_last_error;
   }
-  
+
 =head1 DESCRIPTION
 
 This class provides an easy API to check European VAT numbers' syntax,
@@ -72,12 +72,12 @@ REST API provided by their HMRC.
 =item B<new> Class constructor.
 
     $hvatn=Business::Tax::VAT::Validation->new();
-    
-    
+
+
     If your system is located behind a proxy :
-    
+
     $hvatn=Business::Tax::VAT::Validation->new(-proxy => ['http', 'http://example.com:8001/']);
-    
+
     Note : See LWP::UserAgent for proxy options.
 
 =cut
@@ -155,7 +155,7 @@ May be used rather than C<GB> for checking a Northern Irish company.
 =back
 
     @ms=$hvatn->member_states;
-    
+
 =cut
 
 sub member_states {
@@ -191,7 +191,7 @@ sub regular_expressions {
 =over 4
 
 =item B<check> - Checks if a VAT number exists in the VIES database
-    
+
     $ok=$hvatn->check($vatNumber, [$countryCode]);
 
 You may either provide the VAT number under its complete form (e.g. BE-123456789, BE123456789)
@@ -222,9 +222,9 @@ sub check {
 
 =item B<local_check> - Checks if a VAT number format is valid
     This method is based on regexps only and DOES NOT ask the VIES database
-    
+
     $ok=$hvatn->local_check($VAT, [$member_state]);
-    
+
 
 =cut
 
@@ -259,11 +259,11 @@ This hashref will be reset every time you call check() or local_check()
 =cut
 
 sub information {
-    my ( $self, $key, @other ) = @_; 
+    my ( $self, $key, @other ) = @_;
     if ($key) {
-        return $self->{information}{$key} 
+        return $self->{information}{$key}
     } else {
-        return ($self->{information})    
+        return ($self->{information})
     }
 }
 
@@ -356,7 +356,6 @@ sub _check_vies {
   my ($self, $vatNumber, $countryCode) = @_;
   my $ua = $self->_get_ua();
   my $request = HTTP::Request->new(POST => $self->{baseurl});
-  $request->header(SOAPAction => 'http://www.w3.org/2003/05/soap-envelope');
   $request->content(_in_soap_envelope($vatNumber, $countryCode));
   $request->content_type("Content-Type: application/soap+xml; charset=utf-8");
 


### PR DESCRIPTION
SoapAction header is not required for the service (and I think the original value is wrong anyway. SoapAction is usually something like `SOAPAction: "http://example.com/Service/#Method"` at least everywhere I've had to implement it)

and my editor stripped lots of ending whitespace from lines..

PR: #11 also required to test this (changed `informations` to `information`)

I don't have a way of running a full test suite for this right now (and it looks like the repo does not have a CI action to run it).