### PR TITLE
from 1/1/2023 Belgian enterprise numbers can start with 0 or 1

### DIFF
--- a/lib/Business/Tax/VAT/Validation.pm
+++ b/lib/Business/Tax/VAT/Validation.pm
@@ -93,7 +93,7 @@ sub new {
         re           => {
             ### t/01_localcheck.t tests if these regexps accepts all regular VAT numbers, according to VIES FAQ
             AT => 'U[0-9]{8}',
-            BE => '0[0-9]{9}',
+            BE => '[01][0-9]{9}',
             BG => '[0-9]{9,10}',
             CY => '[0-9]{8}[A-Za-z]',
             CZ => '[0-9]{8,10}',


### PR DESCRIPTION
Every entity is assigned a company number (unique identification number) when it is registered in the Crossroads Bank for Enterprises (CBE).

The structure of the company number has been established by the [Royal Decree of 24 June 2003](https://www.ejustice.just.fgov.be/cgi_loi/change_lg.pl?language=fr&la=F&cn=2003062432&table_name=loi) and takes the form Zxxx.xxx.xxx, the first digit being either 0 or 1.

We are currently using numbers starting with 0: “0xxx.xxx.xxx” (0-series). However, the 0-series is not infinite.  Once this series is exhausted, company numbers will be assigned with the first number being 1: “1xxx.xxx.xxx” (1-series).

Almost all company numbers starting with 0 will be assigned in the course of 2022. Consequently, it is strongly advised that applications using the company number be adapted to use the 1-series company numbers by 1 January 2023.

For further information, please contact the [CBE Helpdesk ](mailto:helpdesk.kbo@economie.fgov.be).

[more info](https://economie.fgov.be/en/themes/enterprises/crossroads-bank-enterprises/actualities/structure-company-number-first)